### PR TITLE
chore: update license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2016 Michel Weststrate
+Copyright (c) 2025 Tyler Williams
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
I think Evin copied this from another MobX repository originally. Keeping the same MIT license, updating the copyright date and original contribution name since [I originally put this together](https://github.com/coolsoftwaretyler/react-compiler-demo-with-mobx-state-tree).